### PR TITLE
Updated to events package over deprecated events-browserify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = System._nodeRequire ? System._nodeRequire('events') : require('events-browserify');
+module.exports = System._nodeRequire ? System._nodeRequire('events') : require('events');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "registry": "npm",
   "dependencies": {
-    "events-browserify": "0.0.1"
+    "events": "1.0.2"
   }
 }


### PR DESCRIPTION
While building a gulp-systembuiler plugin I was running into a very strange error where eslints event emitter's _maxListeners property was not being respected. This was only happening AFTER running my bundleSFX task. This resulted in a re-surfacing of this big https://github.com/eslint/eslint/issues/524

After digging a bit I found that events-browserify is smashing the EventEmitter prototype with its own addListener/on implementations as seen here
https://github.com/defunctzombie/events-browserify/blob/master/events.js#L78 

You can also see here (https://github.com/defunctzombie/events-browserify/blob/master/events.js#L97) that they opt'd to use emitter._events.maxListeners rather then the nodeJS style of emitter._maxListeners.

Since it is smashed eslint's event emitter will use the addListener method from events-browserify.addListener instead of the core node package.

Anyways this was mucking everything up. It looks like the events-browserify is deprecated anyway and should be changed to the events package. This fixes the issue as the events package is a better implementation.

For a temporary workaround, until this gets updated, you can cache addListener prior to running buildSFX and then restore it back after. this is working for me

``` javascript
gulp.task('bundle:dependencies', function(done) {
    // Hack for nodelib-events currently using deprecated events-browserify
    // which smashes EventEmitter.prototype.
    // restore this after the stream is complete
    var cachedAddListener = EventEmitter.prototype.addListener;
    var options = {
        config: {
            paths: {
                '*': 'app/*.js'
            }
        }
    };

    var stream = gulp.src(config.files.jspm.config)
        .pipe(builder.buildSFX({
            module: config.entryModule,
            output: 'app' + (MINIFY ? '.min' : '') + '.js',
            options: options
        }))
        .pipe(ngannotate())
        .pipe(gulpif(MINIFY, uglify()))
        .pipe(gulp.dest(config.build));

        stream.once('end', function() {
            EventEmitter.prototype.on = EventEmitter.prototype.addListener = cachedAddListener
            done();
        });
});
```
